### PR TITLE
Fixed migrations to be compatible with Django 1.5+ custom user models

### DIFF
--- a/allaccess/migrations/0001_initial.py
+++ b/allaccess/migrations/0001_initial.py
@@ -4,6 +4,13 @@ from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
+try:
+    from django.contrib.auth import get_user_model
+except ImportError: # django < 1.5
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
+
 
 class Migration(SchemaMigration):
 
@@ -26,7 +33,7 @@ class Migration(SchemaMigration):
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('identifier', self.gf('django.db.models.fields.CharField')(max_length=255)),
             ('provider', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['allaccess.Provider'])),
-            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], null=True, blank=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(to=User, null=True, blank=True)),
             ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, auto_now_add=True, blank=True)),
             ('modified', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, auto_now=True, blank=True)),
             ('access_token', self.gf('django.db.models.fields.TextField')(default='', blank=True)),


### PR DESCRIPTION
The original migration was using auth_user, not allowing for custom user models supported by Django 1.5+.  The fix was a commit borrowed from (https://github.com/nightaul/django-allauth/commit/7341522ce345f73d3f28ecc07e6ec4378236c247).
