### PR TITLE
Change created/modified defaults to work with Django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
   - TOXENV=py27-1.6.X-swapped,py32-1.6.X-swapped
   - TOXENV=py27-1.7.X,py32-1.7.X
   - TOXENV=py27-1.7.X-swapped,py32-1.7.X-swapped
+  - TOXENV=py27-1.8.X,py32-1.8.X
+  - TOXENV=py27-1.8.X-swapped,py32-1.8.X-swapped
 
 install:
   - pip install tox

--- a/allaccess/migrations/0002_auto_20150511_1853.py
+++ b/allaccess/migrations/0002_auto_20150511_1853.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('allaccess', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='accountaccess',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True),
+        ),
+        migrations.AlterField(
+            model_name='accountaccess',
+            name='modified',
+            field=models.DateTimeField(auto_now=True),
+        ),
+    ]

--- a/allaccess/models.py
+++ b/allaccess/models.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.timezone import now
 
 from .clients import get_client
 from .compat import AUTH_USER_MODEL
@@ -61,8 +60,8 @@ class AccountAccess(models.Model):
     identifier = models.CharField(max_length=255)
     provider = models.ForeignKey(Provider)
     user = models.ForeignKey(AUTH_USER_MODEL, null=True, blank=True)
-    created = models.DateTimeField(auto_now_add=True, default=now)
-    modified = models.DateTimeField(auto_now=True, default=now)
+    created = models.DateTimeField(auto_now_add=True)
+    modified = models.DateTimeField(auto_now=True)
     access_token = EncryptedField(blank=True, null=True, default=None)
 
     objects = AccountAccessManager()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = docs,py27-1.7.X-swapped,py32-1.7.X-swapped,py27-1.7.X,py32-1.7.X,py27-1.6.X-swapped,py32-1.6.X-swapped,py27-1.6.X,py32-1.6.X,py27-1.5.X-swapped,py32-1.5.X-swapped,py27-1.5.X,py32-1.5.X,py27-1.4.X
+envlist = docs,py27-1.8.X-swapped,py32-1.8.X-swapped,py27-1.8.X,py32-1.8.X,py27-1.7.X-swapped,py32-1.7.X-swapped,py27-1.7.X,py32-1.7.X,py27-1.6.X-swapped,py32-1.6.X-swapped,py27-1.6.X,py32-1.6.X,py27-1.5.X-swapped,py32-1.5.X-swapped,py27-1.5.X,py32-1.5.X,py27-1.4.X
 
 [testenv]
 commands = {envpython} runtests.py
@@ -10,6 +10,32 @@ base = mock>=0.8
     south>=0.8.2
 basepy3k = mock>=0.8
     south>=0.8.2,<1.0
+
+[testenv:py32-1.8.X]
+basepython = python3.2
+deps =
+    mock>=0.8
+    django>=1.8,<1.9
+
+[testenv:py27-1.8.X]
+basepython = python2.7
+deps =
+    mock>=0.8
+    django>=1.8,<1.9
+
+[testenv:py32-1.8.X-swapped]
+basepython = python3.2
+deps =
+    mock>=0.8
+    django>=1.8,<1.9
+setenv = SWAPPED = 1
+
+[testenv:py27-1.8.X-swapped]
+basepython = python2.7
+deps =
+    mock>=0.8
+    django>=1.8,<1.9
+setenv = SWAPPED = 1
 
 [testenv:py32-1.7.X]
 basepython = python3.2


### PR DESCRIPTION
Fixes #51. Run tests against Django 1.8. Seems like a relatively minor change so this will be backported and released as v0.7.2