### PR TITLE
Add encrypt-then-MAC using HMAC and the same encryption key

### DIFF
--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -70,7 +70,8 @@ class SignedAESEncryption(object):
 
     def decrypt(self, cypher_text):
         _, prefix, mac, cypher_text = self.split_value(cypher_text)
-        if mac and not compare_digest(self.get_signature(cypher_text), mac):
+        if self.sign and mac and \
+                not compare_digest(self.get_signature(cypher_text), mac):
             raise SignatureException(
                 'EncryptedField cannot be decrypted. '
                 'Did settings.SECRET_KEY change?'

--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -32,7 +32,7 @@ class SignedAESEncryption(object):
         return force_bytes(settings.SECRET_KEY.zfill(32))[:32]
 
     def get_signature(self, value):
-        return hmac.new(self.get_key(), value).hexdigest()
+        return force_bytes(hmac.new(self.get_key(), value).hexdigest())
 
     def get_padding(self, value):
         # We always want at least 2 chars of padding (including zero byte),

--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import binascii
@@ -5,21 +6,13 @@ import hmac
 
 from django.conf import settings
 from django.db import models
+from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_bytes, force_text
 
 try:
     import Crypto.Cipher.AES
 except ImportError:  # pragma: no cover
     raise ImportError('PyCrypto is required to use django-all-access.')
-
-
-def compare_digest(a, b):
-    try:
-        # new in python 2.7.7
-        from hmac import compare_digest
-        return compare_digest(a, b)
-    except ImportError:
-        return a == b
 
 
 class SignatureException(Exception):
@@ -71,7 +64,7 @@ class SignedAESEncryption(object):
     def decrypt(self, cypher_text):
         _, prefix, mac, cypher_text = self.split_value(cypher_text)
         if self.sign and mac and \
-                not compare_digest(self.get_signature(cypher_text), mac):
+                not constant_time_compare(self.get_signature(cypher_text), mac):
             raise SignatureException(
                 'EncryptedField cannot be decrypted. '
                 'Did settings.SECRET_KEY change?'

--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import binascii
+import hmac
 
 from django.conf import settings
 from django.db import models
@@ -10,6 +11,15 @@ try:
     import Crypto.Cipher.AES
 except ImportError:  # pragma: no cover
     raise ImportError('PyCrypto is required to use django-all-access.')
+
+
+def compare_digest(a, b):
+    try:
+        # new in python 2.7.7
+        from hmac import compare_digest
+        return compare_digest(a, b)
+    except ImportError:
+        return a == b
 
 
 class EncryptedField(models.TextField):

--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -26,54 +26,51 @@ class SignatureException(Exception):
     pass
 
 
-class EncryptedField(models.TextField):
-    """
-    This code is based on http://www.djangosnippets.org/snippets/1095/
-    and django-fields https://github.com/svetlyak40wt/django-fields
-    """
+class SignedAESEncryption(object):
     cipher_class = Crypto.Cipher.AES
     prefix = b'$AES'
+    #: enable hmac signature of cypher text with the same key (default: True)
+    sign = True
 
     def __init__(self, *args, **kwargs):
-        self.cipher = self.cipher_class.new(self._get_key())
-        super(EncryptedField, self).__init__(*args, **kwargs)
+        self.cipher = self.cipher_class.new(self.get_key())
 
-    def _get_key(self):
+    def get_key(self):
         return force_bytes(settings.SECRET_KEY)[:32]
 
-    def _is_encrypted(self, value):
-        return value.startswith(self.prefix)
+    def get_signature(self, value):
+        return hmac.new(self.get_key(), value).hexdigest()
 
-    def _split_value(self, value):
+    def get_padding(self, value):
+        # We always want at least 2 chars of padding (including zero byte),
+        # so we could have up to block_size + 1 chars.
+        mod = (len(value) + 2) % self.cipher.block_size
+        return self.cipher.block_size - mod + 2
+
+    def add_padding(self, clear_text):
+        padding = self.get_padding(clear_text)
+        if padding > 0:
+            return clear_text + b'\x00' + b'*' * (padding - 1)
+        return clear_text
+
+    def split_value(self, value):
         #: split value from database into _, prefix, mac, cypher_text
         parts = value.split(b'$')
         if len(parts) == 3:
             parts.insert(2, None)
         return parts
 
-    def _is_signed(self, value):
+    def is_encrypted(self, value):
+        return value.startswith(self.prefix)
+
+    def is_signed(self, value):
         #: value consists of 3 or 4 $ separated parts, check for mac in 2nd
-        _, prefix, mac, cypher_text = self._split_value(value)
+        _, prefix, mac, cypher_text = self.split_value(value)
         return mac is not None
 
-    def _get_padding(self, value):
-        # We always want at least 2 chars of padding (including zero byte),
-        # so we could have up to block_size + 1 chars.
-        mod = (len(value) + 2) % self.cipher.block_size
-        return self.cipher.block_size - mod + 2
-
-    def _add_padding(self, clear_text):
-        padding = self._get_padding(clear_text)
-        if padding > 0:
-            return clear_text + b'\x00' + b'*' * (padding - 1)
-        return clear_text
-
-    def _get_signature(self, value):
-        return hmac.new(self._get_key(), value).hexdigest()
-
-    def _decrypt(self, cypher_text):
-        _, prefix, mac, cypher_text = self._split_value(cypher_text)
-        if mac and not compare_digest(self._get_signature(cypher_text), mac):
+    def decrypt(self, cypher_text):
+        _, prefix, mac, cypher_text = self.split_value(cypher_text)
+        if mac and not compare_digest(self.get_signature(cypher_text), mac):
             raise SignatureException(
                 'EncryptedField cannot be decrypted. '
                 'Did settings.SECRET_KEY change?'
@@ -81,21 +78,33 @@ class EncryptedField(models.TextField):
         cypher_text = binascii.a2b_hex(cypher_text)
         return self.cipher.decrypt(cypher_text).split(b'\x00')[0]
 
-    def _encrypt(self, clear_text, sign=True):
-        clear_text = self._add_padding(clear_text)
+    def encrypt(self, clear_text):
+        clear_text = self.add_padding(clear_text)
         cypher_text = binascii.b2a_hex(self.cipher.encrypt(clear_text))
         parts = [self.prefix]
-        if sign:
-            parts.append(self._get_signature(cypher_text))
+        if self.sign:
+            parts.append(self.get_signature(cypher_text))
         parts.append(cypher_text)
         return b'$'.join(parts)
+
+
+class EncryptedField(models.TextField):
+    """
+    This code is based on http://www.djangosnippets.org/snippets/1095/
+    and django-fields https://github.com/svetlyak40wt/django-fields
+    """
+    encryption_class = SignedAESEncryption
+
+    def __init__(self, *args, **kwargs):
+        self.cipher = self.encryption_class()
+        super(EncryptedField, self).__init__(*args, **kwargs)
 
     def from_db_value(self, value, expression, connection, context):
         if value is None:
             return value
         value = force_bytes(value)
-        if self._is_encrypted(value):
-            return force_text(self._decrypt(value))
+        if self.cipher.is_encrypted(value):
+            return force_text(self.cipher.decrypt(value))
         return force_text(value)
 
     def get_db_prep_value(self, value, connection=None, prepared=False):
@@ -105,6 +114,6 @@ class EncryptedField(models.TextField):
         if value is None:
             return None
         value = force_bytes(value)
-        if not self._is_encrypted(value):
-            value = self._encrypt(value)
+        if not self.cipher.is_encrypted(value):
+            value = self.cipher.encrypt(value)
         return force_text(value)

--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -66,6 +66,9 @@ class EncryptedField(models.TextField):
             clear_text = clear_text + b'\x00' + b'*' * (padding - 1)
         return self.prefix + binascii.b2a_hex(self.cipher.encrypt(clear_text))
 
+    def _get_signature(self, value):
+        return hmac.new(force_bytes(settings.SECRET_KEY), value).hexdigest()
+
     def from_db_value(self, value, expression, connection, context):
         if value is None:
             return value

--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -31,8 +31,11 @@ class EncryptedField(models.TextField):
     prefix = b'$AES'
 
     def __init__(self, *args, **kwargs):
-        self.cipher = self.cipher_class.new(force_bytes(settings.SECRET_KEY)[:32])
+        self.cipher = self.cipher_class.new(self._get_key())
         super(EncryptedField, self).__init__(*args, **kwargs)
+
+    def _get_key(self):
+        return force_bytes(settings.SECRET_KEY)[:32]
 
     def _is_encrypted(self, value):
         return value.startswith(self.prefix)
@@ -62,7 +65,7 @@ class EncryptedField(models.TextField):
         return clear_text
 
     def _get_signature(self, value):
-        return hmac.new(force_bytes(settings.SECRET_KEY), value).hexdigest()
+        return hmac.new(self._get_key(), value).hexdigest()
 
     def _decrypt(self, cypher_text):
         _, prefix, hmac, cypher_text = self._split_value(cypher_text)

--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -37,6 +37,18 @@ class EncryptedField(models.TextField):
     def _is_encrypted(self, value):
         return value.startswith(self.prefix)
 
+    def _split_value(self, value):
+        #: split value from database into _, prefix, hmac, cypher_text
+        parts = value.split(b'$')
+        if len(parts) == 3:
+            parts.insert(2, None)
+        return parts
+
+    def _is_signed(self, value):
+        #: value consists of 3 or 4 $ separated parts, check for hmac in 2nd
+        _, prefix, hmac, cypher_text = self._split_value(value)
+        return hmac is not None
+
     def _get_padding(self, value):
         # We always want at least 2 chars of padding (including zero byte),
         # so we could have up to block_size + 1 chars.

--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -36,7 +36,7 @@ class SignedAESEncryption(object):
         self.cipher = self.cipher_class.new(self.get_key())
 
     def get_key(self):
-        return force_bytes(settings.SECRET_KEY)[:32]
+        return force_bytes(settings.SECRET_KEY.zfill(32))[:32]
 
     def get_signature(self, value):
         return hmac.new(self.get_key(), value).hexdigest()

--- a/allaccess/fields.py
+++ b/allaccess/fields.py
@@ -41,16 +41,16 @@ class EncryptedField(models.TextField):
         return value.startswith(self.prefix)
 
     def _split_value(self, value):
-        #: split value from database into _, prefix, hmac, cypher_text
+        #: split value from database into _, prefix, mac, cypher_text
         parts = value.split(b'$')
         if len(parts) == 3:
             parts.insert(2, None)
         return parts
 
     def _is_signed(self, value):
-        #: value consists of 3 or 4 $ separated parts, check for hmac in 2nd
-        _, prefix, hmac, cypher_text = self._split_value(value)
-        return hmac is not None
+        #: value consists of 3 or 4 $ separated parts, check for mac in 2nd
+        _, prefix, mac, cypher_text = self._split_value(value)
+        return mac is not None
 
     def _get_padding(self, value):
         # We always want at least 2 chars of padding (including zero byte),


### PR DESCRIPTION
Maybe a step towards key rotation (#22) is detecting valid key before decrypting.

In any case, i was annoyed by the cryptic (little pun intended :)) `DjangoUnicodeDecodeError` that resulted from having the wrong key and was looking to actually detect valid credentials before attempting to decrypt. So i added a HMAC (default, md5) signature between `$AES$` and the cyphertext. Now invalid key raises a `SignatureException`.

This still works with unsigned database values, as it simply checks for the number of items when splitting the value at the `$`. I also ripped out the encryption stuff into its own class, which has a `sign` attribute to get back the old behavior (incl the `DjangoUnicodeDecodeError`).