### PR TITLE
Add option for user to pass params when getting profile info

### DIFF
--- a/allaccess/clients.py
+++ b/allaccess/clients.py
@@ -26,10 +26,10 @@ class BaseOAuthClient(object):
         "Fetch access token from callback request."
         raise NotImplementedError('Defined in a sub-class')  # pragma: no cover
 
-    def get_profile_info(self, raw_token):
+    def get_profile_info(self, raw_token, profile_info_params):
         "Fetch user profile information."
         try:
-            response = self.request('get', self.provider.profile_url, token=raw_token)
+            response = self.request('get', self.provider.profile_url, token=raw_token, params=profile_info_params)
             response.raise_for_status()
         except RequestException as e:
             logger.error('Unable to fetch user profile: {0}'.format(e))

--- a/allaccess/clients.py
+++ b/allaccess/clients.py
@@ -26,7 +26,7 @@ class BaseOAuthClient(object):
         "Fetch access token from callback request."
         raise NotImplementedError('Defined in a sub-class')  # pragma: no cover
 
-    def get_profile_info(self, raw_token, profile_info_params):
+    def get_profile_info(self, raw_token, profile_info_params={}):
         "Fetch user profile information."
         try:
             response = self.request('get', self.provider.profile_url, token=raw_token, params=profile_info_params)

--- a/allaccess/views.py
+++ b/allaccess/views.py
@@ -66,6 +66,7 @@ class OAuthCallback(OAuthClientMixin, View):
     "Base OAuth callback view."
 
     provider_id = None
+    profile_info_params = None
 
     def get(self, request, *args, **kwargs):
         name = kwargs.get('provider', '')
@@ -82,8 +83,10 @@ class OAuthCallback(OAuthClientMixin, View):
             raw_token = client.get_access_token(self.request, callback=callback)
             if raw_token is None:
                 return self.handle_login_failure(provider, "Could not retrieve token.")
+            # Fetch profile info params
+            profile_info_params = self.get_profile_info_params()
             # Fetch profile info
-            info = client.get_profile_info(raw_token)
+            info = client.get_profile_info(raw_token, profile_info_params)
             if info is None:
                 return self.handle_login_failure(provider, "Could not retrieve profile.")
             identifier = self.get_user_id(provider, info)
@@ -130,6 +133,10 @@ class OAuthCallback(OAuthClientMixin, View):
             'password': None
         }
         return User.objects.create_user(**kwargs)
+
+    def get_profile_info_params(self):
+        "Return params that are going to be sent when getting user profile info"
+        return self.profile_info_params or {}
 
     def get_user_id(self, provider, info):
         "Return unique identifier from the profile info."


### PR DESCRIPTION
Facebook API requires that you pass the 'fields' URL param when getting the profile info if you want to get something besides name and id. This pull request adds the option to add profile_info_params, which are going to be sent with the profile info request.